### PR TITLE
Fix failed decode crash on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Chirp for Flutter
 
+## 1.0.1 - 07/01/20
+
+- Fix iOS failed decode bug
+
 ## 1.0.0 - 24/10/19
 
 - Rename package to `chirp_flutter`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ChirpSDK
 
-Send data with sound.
+Send data with sound - [chirp_flutter](https://pub.dev/packages/chirp_flutter)
 
 ## Getting Started
 
@@ -20,7 +20,7 @@ Copy and paste your Chirp app key, secret and chosen configuration into the
 
 Please see the [example](https://github.com/chirp/chirp-flutter/tree/master/example)
 for a more detailed run through of how to use the Chirp SDK.
-For example the Chirp SDK async methods must called inside a Future async parent method.
+For example the Chirp SDK methods must be called inside a Future async parent method.
 
 ## Permissions
 

--- a/ios/Classes/ChirpFlutterPlugin.h
+++ b/ios/Classes/ChirpFlutterPlugin.h
@@ -36,6 +36,6 @@
 @end
 
 @interface ReceivedStreamHandler : NSObject<FlutterStreamHandler>
-- (void)send:(FlutterStandardTypedData *)data channel:(NSNumber *)channel;
+- (void)send:(FlutterStandardTypedData * _Nullable)data channel:(NSNumber *)channel;
 @end
 

--- a/ios/Classes/ChirpFlutterPlugin.m
+++ b/ios/Classes/ChirpFlutterPlugin.m
@@ -105,13 +105,18 @@
 
   [weakSelf.chirp setReceivedBlock:^(NSData * _Nullable data, NSUInteger channel)
    {
-     /*------------------------------------------------------------------------------
-      * receivedBlock is called when a receive event has completed.
-      * If the payload was decoded successfully, it is passed in data.
-      * Otherwise, data is null.
-      *----------------------------------------------------------------------------*/
-    [weakSelf.receivedStreamHandler send:[FlutterStandardTypedData typedDataWithBytes:data]
-                                 channel:[NSNumber numberWithInteger:channel]];
+      /*------------------------------------------------------------------------------
+       * receivedBlock is called when a receive event has completed.
+       * If the payload was decoded successfully, it is passed in data.
+       * Otherwise, data is null.
+       *----------------------------------------------------------------------------*/
+    if (data) {
+      [weakSelf.receivedStreamHandler send:[FlutterStandardTypedData typedDataWithBytes:data]
+                                   channel:[NSNumber numberWithInteger:channel]];
+    } else {
+      [weakSelf.receivedStreamHandler send:[NSNull null]
+                                   channel:[NSNumber numberWithInteger:channel]];
+    }
    }];
 }
 
@@ -347,7 +352,7 @@
   return nil;
 }
 
-- (void)send:(FlutterStandardTypedData *)data channel:(NSNumber *)channel {
+- (void)send:(FlutterStandardTypedData * _Nullable)data channel:(NSNumber *)channel {
   if (_eventSink) {
     NSDictionary *dictionary = @{ @"data": data, @"channel": channel };
     _eventSink(dictionary);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chirp_flutter
 description: Chirp enables your apps to send and receive information using sound.
-version: 1.0.0
+version: 1.0.1
 author: Asio Ltd <developers@chirp.io>
 homepage: https://github.com/chirp/chirp-flutter
 


### PR DESCRIPTION
**What:** SDK crashes on a failed decode on iOS
**Why:** The `FlutterStandardTypedData` type cannot be initialised with `nil` bytes. Also need to set the argument to be `Nullable`. 

Closes: #22 